### PR TITLE
Add bindaddress option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.iml
+.idea/
+.gradle/
+build/
+hm2mqtt.devcache

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ Examples:
   Local address used when sending init (callback) requests to the XML-RPC server. Default is
   the result of getHostAddress(). Set this when hm2mqtt has trouble determining your local host's
   address automatically.
+
+- hm.bindaddress
+
+  Local address and port used to listen for callback requests. If not specified hm2mqtt will pick a valid local address
+  and a random port
+
+  Example: Listen on all local adresses on port 3333: 0.0.0.0:3333
   
 - hm.disableReGa
 

--- a/src/main/java/com/tellerulam/hm2mqtt/XMLRPCServer.java
+++ b/src/main/java/com/tellerulam/hm2mqtt/XMLRPCServer.java
@@ -16,7 +16,13 @@ public class XMLRPCServer implements Runnable
 	{
 		ss=new ServerSocket();
 		ss.setReuseAddress(true);
-		ss.bind(null);
+		String bindaddress=System.getProperty("hm2mqtt.hm.bindaddress");
+		if(bindaddress == null)
+			ss.bind(null);
+		else{
+			String[] parts = bindaddress.split(":");
+			ss.bind(new InetSocketAddress(parts[0], Integer.parseInt(parts[1])));
+		}
 		new XMLRPCAcceptor().start();
         String localhost=System.getProperty("hm2mqtt.hm.localhost");
         if(localhost==null)


### PR DESCRIPTION
In order to run hm2mqtt inside a docker container and exposing the port I needed to know the listening port for callbacks before starting hm2mqtt. I added the option hm.bindaddress and added proper documentation, too.
