### PR TITLE
Support for sslVersion parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Examples:
   Note that using SSL connections requires additional configuration at the JVM level. For example, the
   broker's certificate needs to be verifiable by the JVM using it's CA cert store.
   
+- mqtt.sslVersion
+
+  Optional, define the SSL version that should be used when connecting to the MQTT broker.
+  Possible values are limited by the executing JVM, but could be one of:
+  SSL, SSLv2, SSLv3, TLS, TLSv1, TLSv1.1, TLSv1.2
+
 - mqtt.clientid
 
   ClientID to use in the MQTT connection. Defaults to "hm2mqtt".
@@ -136,7 +142,7 @@ Examples:
 - mqtt.topic
 
   The topic prefix used for publishing and subscribing. Defaults to "hm/".
-^
+
 - mqtt.username
 - mqtt.password
 

--- a/src/main/java/com/tellerulam/hm2mqtt/MQTTHandler.java
+++ b/src/main/java/com/tellerulam/hm2mqtt/MQTTHandler.java
@@ -3,9 +3,12 @@ package com.tellerulam.hm2mqtt;
 import java.io.*;
 import java.math.*;
 import java.nio.charset.*;
+import java.security.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
+
+import javax.net.ssl.*;
 
 import org.eclipse.paho.client.mqttv3.*;
 import org.eclipse.paho.client.mqttv3.persist.*;
@@ -202,6 +205,25 @@ public class MQTTHandler
 			copts.setUserName(username);
 			copts.setPassword(password.toCharArray());
 			L.fine("Using MQTT username "+username);
+		}
+		String sslVersion=System.getProperty("hm2mqtt.mqtt.sslVersion");
+		if (sslVersion!=null)
+		{
+			try
+			{
+				SSLContext context = SSLContext.getInstance(sslVersion);
+				// TODO Maybe use custom trust manager for CA certs https://gist.github.com/sharonbn/4104301
+				context.init(null, null, null);
+				copts.setSocketFactory(context.getSocketFactory());
+			}
+			catch(NoSuchAlgorithmException nsae)
+			{
+				L.log(Level.WARNING, "Error creating SSLContext, check your configuration", nsae);
+			}
+			catch(KeyManagementException kme)
+			{
+				L.log(Level.WARNING, "Error initializing SSLContext, check your configuration", kme);
+			}
 		}
 		try
 		{


### PR DESCRIPTION
Added a mqtt.sslVersion parameter that allows us to specify the TLS version (ie. TLSv1.2) that should be used when connecting to MQTT.

Closes owagner/hm2mqtt#12
